### PR TITLE
Commit inicial

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
+        aws-region: "us-east-1"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -57,7 +57,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
+        aws-region: "us-east-1"
 
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set the AWS region to 'us-east-1' directly in the CI/CD workflow configuration.